### PR TITLE
Add explicit constructors to HMM and Operator

### DIFF
--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -1,0 +1,37 @@
+name: Type checking
+
+on:
+ push:
+   branches:
+     - main
+     - 'version-**'
+ pull_request:
+
+jobs:
+  type-checking:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        python-version: ['3.8']
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install DAPPERand dependencies
+      run: |
+        pip install .
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r types-requirements.txt
+    - name: Run mypy
+      run: |
+        mypy -p dapper
+

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,45 @@
+[mypy]
+plugins = numpy.typing.mypy_plugin
+; strict = True strict with numpy seems to have some issues.
+
+[mypy-matplotlib.*]
+ignore_missing_imports = True
+
+[mypy-scipy.*]
+ignore_missing_imports = True
+
+[mypy-mpl_tools.*]
+ignore_missing_imports = True
+
+[mypy-struct_tools.*]
+ignore_missing_imports = True
+
+; TODO: Figure out why this is needed in the code base.
+[mypy-IPython.*]
+ignore_missing_imports = True
+
+; TODO: Try replacing patlib with third-party
+[mypy-patlib.*]
+ignore_missing_imports = True
+
+[mypy-colorama.*]
+ignore_missing_imports = True
+
+[mypy-tqdm.*]
+ignore_missing_imports = True
+
+[mypy-dill.*]
+ignore_missing_imports = True
+
+[mypy-ipdb.*]
+ignore_missing_imports = True
+
+[mypy-mpl_toolkits.*]
+ignore_missing_imports = True
+
+; TODO: Not well maintained project...
+[mypy-multiprocessing_on_dill.*]
+ignore_missing_imports = True
+
+[mypy-threadpoolctl.*]
+ignore_missing_imports = True

--- a/dapper/mods/DoublePendulum/settings101.py
+++ b/dapper/mods/DoublePendulum/settings101.py
@@ -6,20 +6,15 @@ from dapper.mods.DoublePendulum import step, x0, LP_setup, dstep_dx
 
 t = modelling.Chronology(0.01, dko=100, T=30, BurnIn=10)
 
-Dyn = {
-    'M': len(x0),
-    'model': step,
-    'noise': 0,
-    'linear': dstep_dx,
-}
+Dyn = modelling.Operator(M=len(x0), model=step, linear=dstep_dx, noise=0)
 
 X0 = modelling.GaussRV(mu=x0, C=0.01**2)
 
 jj = [0, 2]
 Obs = modelling.partial_Id_Obs(len(x0), jj)
-Obs['noise'] = 0.1**2
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=0.1**2)
 
-HMM = modelling.HiddenMarkovModel(Dyn, Obs, t, X0, LP=LP_setup(jj))
+HMM = modelling.HiddenMarkovModel(Dyn, Obs, t, X0, liveplotters=LP_setup(jj))
 
 ####################
 # Suggested tuning

--- a/dapper/mods/Id/__init__.py
+++ b/dapper/mods/Id/__init__.py
@@ -9,7 +9,9 @@ import dapper.mods as modelling
 tseq = modelling.Chronology(1, dko=1, Ko=2000, Tplot=10, BurnIn=0)
 M = 4
 Obs = {'noise': 2, 'M': M}
+Obs = modelling.Operator(M=M, noise=0.1**2)
 Dyn = {'noise': 1, 'M': M}
+Dyn = modelling.Operator(M=M, noise=1)
 X0 = modelling.GaussRV(C=1, M=M)
 
 HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0)

--- a/dapper/mods/Ikeda/some_settings_01.py
+++ b/dapper/mods/Ikeda/some_settings_01.py
@@ -14,12 +14,13 @@ Dyn = {
     'model': step,
     'noise': 0,
 }
+Dyn = modelling.Operator(M=Nx, model=step, noise=0)
 
 X0 = modelling.GaussRV(C=.1, mu=x0)
 
 jj = np.arange(Nx)  # obs_inds
 Obs = modelling.partial_Id_Obs(Nx, jj)
-Obs['noise'] = .1  # modelling.GaussRV(C=CovMat(1*eye(Nx)))
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=.1)
 
 HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0)
 

--- a/dapper/mods/KS/bocquet2019.py
+++ b/dapper/mods/KS/bocquet2019.py
@@ -12,18 +12,14 @@ Nx = KS.Nx
 # nRepeat=10
 tseq = modelling.Chronology(KS.dt, dko=2, Ko=2*10**4, BurnIn=2*10**3, Tplot=Tplot)
 
-Dyn = {
-    'M': Nx,
-    'model': KS.step,
-    'linear': KS.dstep_dx,
-    'noise': 0,
-}
-
+Dyn = modelling.Operator(M=Nx, model=KS.step, linear=KS.dstep_dx, noise=0)
 X0 = modelling.GaussRV(mu=KS.x0, C=0.001)
 
 Obs = modelling.Id_Obs(Nx)
 Obs['noise'] = 1
 Obs['localizer'] = nd_Id_localization((Nx,), (4,))
+
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=Obs.get("noise"), localizer=Obs.get("localizer"))
 
 HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0)
 

--- a/dapper/mods/LA/__init__.py
+++ b/dapper/mods/LA/__init__.py
@@ -13,6 +13,7 @@ ora.ox.ac.uk/objects/uuid:9f9961f0-6906-4147-a8a9-ca9f2d0e4a12
 """
 
 import numpy as np
+import numpy.typing as npt
 import scipy.linalg as sla
 from scipy import sparse
 
@@ -42,7 +43,7 @@ def Fmat(Nx, c, dx, dt):
     return F
 
 
-def basis_vector(Nx, k):
+def basis_vector(Nx: int, k: int) -> npt.NDArray[np.float_]:
     """Generate basis vectors.
 
     - Nx - state vector length
@@ -63,7 +64,6 @@ def basis_vector(Nx, k):
     s  = s/sd
 
     return s
-
 
 # Initialization as suggested by sakov'2008 "implications of...",
 # (but with some minor differences).
@@ -89,7 +89,7 @@ def sinusoidal_sample(Nx, k, N):
     return sample
 
 
-def periodic_distance_range(M):
+def periodic_distance_range(M: int) -> npt.NDArray[np.float_]:
     return np.minimum(np.arange(M), np.arange(M, 0, -1))
     # return np.roll(np.abs(np.arange(M) - M//2), (M+1)//2)
     # return np.concatenate((range((M+1)//2), range(M//2,0,-1)))

--- a/dapper/mods/LA/evensen2009.py
+++ b/dapper/mods/LA/evensen2009.py
@@ -31,13 +31,7 @@ def step(x, t, dt):
     assert dt == tseq.dt
     return x @ Fm.T
 
-
-Dyn = {
-    'M': Nx,
-    'model': step,
-    'linear': lambda x, t, dt: Fm,
-    'noise': 0,
-}
+Dyn = modelling.Operator(M=Nx, model=step, linear=lambda x, t, dt: Fm, noise=0)
 
 # In the animation, it can sometimes/somewhat occur
 # that the truth is outside 3*sigma !!!
@@ -49,8 +43,9 @@ X0 = modelling.RV(M=Nx, func = lambda N: a*sinusoidal_sample(Nx, wnum, N))
 
 Obs = modelling.partial_Id_Obs(Nx, jj)
 Obs['noise'] = 0.01
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=0.01)
 
-HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0, LP=LPs(jj))
+HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0, liveplotters=LPs(jj))
 
 
 ####################

--- a/dapper/mods/LA/raanes2015.py
+++ b/dapper/mods/LA/raanes2015.py
@@ -15,8 +15,7 @@ Ny = 40
 
 jj = modelling.linspace_int(Nx, Ny)
 Obs = modelling.partial_Id_Obs(Nx, jj)
-Obs['noise'] = 0.01
-
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=0.01)
 
 #################
 #  Noise setup  #
@@ -58,14 +57,9 @@ def step(x, t, dt):
     return x @ Fm.T
 
 
-Dyn = {
-    'M': Nx,
-    'model': lambda x, t, dt: damp * step(x, t, dt),
-    'linear': lambda x, t, dt: damp * Fm,
-    'noise': modelling.GaussRV(C=modelling.CovMat(L, 'Left')),
-}
+Dyn = modelling.Operator(M=Nx, model=lambda x, t, dt: damp * step(x, t, dt), linear=lambda x, t, dt: damp * Fm, noise=modelling.GaussRV(C=modelling.CovMat(L, 'Left')))
 
-HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0, LP=LPs(jj))
+HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0, liveplotters=LPs(jj))
 
 
 ####################

--- a/dapper/mods/LA/small.py
+++ b/dapper/mods/LA/small.py
@@ -24,12 +24,7 @@ def step(x, t, dt):
     return x @ Fm.T
 
 
-Dyn = {
-    'M': Nx,
-    'model': step,
-    'linear': lambda x, t, dt: Fm,
-    'noise': 0,
-}
+Dyn = modelling.Operator(M=Nx, model=step, linear=lambda x, t, dt: Fm, noise=0)
 
 X0 = modelling.GaussRV(mu=np.zeros(Nx), C=homogeneous_1D_cov(Nx, Nx/8, kind='Gauss'))
 
@@ -37,9 +32,9 @@ Ny  = 4
 jj  = modelling.linspace_int(Nx, Ny)
 Obs = modelling.partial_Id_Obs(Nx, jj)
 Obs['noise'] = 0.01
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=0.01)
 
-
-HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0, LP=LPs(jj))
+HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0, liveplotters=LPs(jj))
 
 
 ####################

--- a/dapper/mods/Lorenz05/settings01.py
+++ b/dapper/mods/Lorenz05/settings01.py
@@ -7,20 +7,14 @@ from dapper.tools.localization import nd_Id_localization
 # Sakov uses K=300000, BurnIn=1000*0.05
 tseq = modelling.Chronology(0.002, dto=0.05, Ko=400, Tplot=2, BurnIn=5)
 
-model = Model(b=8)
+model = Model(b=8) 
 
-Dyn = {
-    'M': model.M,
-    'model': model.step,
-    'noise': 0,
-    'object': model,
-}
+Dyn = modelling.Operator(M=model.M, model=model.step, noise=0, object=model)
 
 X0 = modelling.GaussRV(mu=model.x0, C=0.001)
 
 jj = np.arange(model.M)  # obs_inds
 Obs = modelling.partial_Id_Obs(model.M, jj)
-Obs['noise'] = 1
-Obs['localizer'] = nd_Id_localization((model.M,), (6,))
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=1, localizer=nd_Id_localization((model.M,), (6,)))
 
 HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0)

--- a/dapper/mods/Lorenz63/anderson2010rhf.py
+++ b/dapper/mods/Lorenz63/anderson2010rhf.py
@@ -15,11 +15,12 @@ Dyn = {
     'linear': dstep_dx,
     'noise': 0,
 }
+Dyn = modelling.Operator(M=Nx, model=step, linear=dstep_dx, noise=0)
 
 X0 = modelling.GaussRV(C=2, mu=x0)
 
 Obs = modelling.partial_Id_Obs(Nx, np.arange(Nx))
-Obs['noise'] = 8.0
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=8.0)
 
 HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0)
 

--- a/dapper/mods/Lorenz63/extras.py
+++ b/dapper/mods/Lorenz63/extras.py
@@ -1,5 +1,7 @@
 """Extra functionality (not necessary for the EnKF or the particle filter)."""
 
+from typing import List, Callable
+
 import numpy as np
 
 import dapper.mods.Lorenz63 as core
@@ -27,7 +29,7 @@ def dstep_dx(x, t, dt):
 params = dict(labels='xyz', Tplot=1)
 
 
-def LPs(jj=None, params=params): return [
+def LPs(jj=None, params=params) -> List[Callable]: return [
     (1, LP.correlations),
     (1, LP.sliding_marginals(jj, zoomy=0.8, **params)),
     (1, LP.phase_particles(is_3d=True, obs_inds=jj, **params)),

--- a/dapper/mods/Lorenz63/mandel2016.py
+++ b/dapper/mods/Lorenz63/mandel2016.py
@@ -7,11 +7,7 @@ HMM = _HMM.copy()
 # HMM.tseq = modelling.Chronology(0.01,Ko=10**5,BurnIn=500), with dko in [5:55].
 # But it's pretty safe to shorten the BurnIn and Ko.
 
-HMM.Obs = modelling.Operator(**{
-    'M': 3,
-    'model': lambda x, t: x**3,
-    'noise': 8,
-})
+HMM.Obs = modelling.Operator(M=3, model=lambda x, t: x**3, noise=8)
 
 # It is unclear whether the model error (cov Q) is used
 # just for the DA method, or also for the truth.

--- a/dapper/mods/Lorenz63/sakov2012.py
+++ b/dapper/mods/Lorenz63/sakov2012.py
@@ -9,18 +9,14 @@ tseq = modelling.Chronology(0.01, dko=25, Ko=1000, Tplot=Tplot, BurnIn=4*Tplot)
 
 Nx = len(x0)
 
-Dyn = {
-    'M': Nx,
-    'model': step,
-    'linear': dstep_dx,
-    'noise': 0,
-}
-
+Dyn = modelling.Operator(M=Nx, model=step, linear=dstep_dx, noise=0)
 X0 = modelling.GaussRV(C=2, mu=x0)
 
 jj = np.arange(Nx)  # obs_inds
 Obs = modelling.partial_Id_Obs(Nx, jj)
 Obs['noise'] = 2  # modelling.GaussRV(C=CovMat(2*eye(Nx)))
+
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=Obs.get("noise"), localizer=Obs.get("localizer"))
 
 HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0)
 

--- a/dapper/mods/Lorenz63/wiljes2017.py
+++ b/dapper/mods/Lorenz63/wiljes2017.py
@@ -12,7 +12,8 @@ HMM.tseq = modelling.Chronology(0.01, dko=12, T=4**5, BurnIn=4)
 jj = np.array([0])
 Obs = modelling.partial_Id_Obs(Nx, jj)
 Obs['noise'] = 8
-HMM.Obs = modelling.Operator(**Obs)
+
+HMM.Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=8)
 
 ####################
 # Suggested tuning

--- a/dapper/mods/Lorenz84/pajonk2012.py
+++ b/dapper/mods/Lorenz84/pajonk2012.py
@@ -16,21 +16,17 @@ Ny = Nx
 day = 0.05/6 * 24  # coz dt=0.05 <--> 6h in "model time scale"
 t = modelling.Chronology(0.05, dko=1, T=200*day, BurnIn=10*day)
 
-Dyn = {
-    'M': Nx,
-    'model': step,
-    'linear': dstep_dx,
-    'noise': 0,
-}
+Dyn = modelling.Operator(M=Nx, model=step, linear=dstep_dx, noise=0)
 
 # X0 = modelling.GaussRV(C=0.01,M=Nx) # Decreased from Pajonk's C=1.
 X0 = modelling.GaussRV(C=0.01, mu=x0)
 
 jj = np.arange(Nx)
 Obs = modelling.partial_Id_Obs(Nx, jj)
-Obs['noise'] = 0.1
 
-HMM = modelling.HiddenMarkovModel(Dyn, Obs, t, X0, LP=LPs(jj))
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=0.1)
+
+HMM = modelling.HiddenMarkovModel(Dyn, Obs, t, X0, liveplotters=LPs(jj))
 
 ####################
 # Suggested tuning

--- a/dapper/mods/Lorenz96/anderson2009.py
+++ b/dapper/mods/Lorenz96/anderson2009.py
@@ -26,16 +26,11 @@ H[np.arange(20), ii_above] = w_above
 y2x_dists = pairwise_distances(obs_sites[:, None], np.arange(Nx)[:, None], domain=(Nx,))
 batches = np.arange(40)[:, None]
 # Define operator
-Obs = {
-    'M': len(H),
-    'model': lambda E, t: E @ H.T,
-    'linear': lambda E, t: H,
-    'noise': 1,
-    'localizer': localization_setup(lambda t: y2x_dists, batches),
-}
+
+Obs = modelling.Operator(M=len(H), model=lambda E, t: E @ H.T, linear=lambda E, t: H, noise=1, localizer=localization_setup(lambda t: y2x_dists, batches))
 
 HMM = modelling.HiddenMarkovModel(
-    Dyn, Obs, tseq, X0, LP=LPs(),
+    Dyn, Obs, tseq, X0, liveplotters=LPs(),
     sectors={'land': np.arange(*xtrema(obs_sites)).astype(int)})
 
 ####################

--- a/dapper/mods/Lorenz96/bocquet2010.py
+++ b/dapper/mods/Lorenz96/bocquet2010.py
@@ -8,17 +8,13 @@ from dapper.mods.Lorenz96 import step
 tseq = modelling.Chronology(0.05, dko=1, T=4**3, BurnIn=20)
 
 Nx = 10
-Dyn = {
-    'M': Nx,
-    'model': step,
-    'noise': 0,
-}
+Dyn = modelling.Operator(M=Nx, model=step, noise=0)
 
 X0 = modelling.GaussRV(M=Nx, C=0.001)
 
 jj = np.arange(0, Nx, 2)
 Obs = modelling.partial_Id_Obs(Nx, jj)
-Obs['noise'] = 1.5
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=1.5)
 
 HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0)
 

--- a/dapper/mods/Lorenz96/bocquet2010_m40.py
+++ b/dapper/mods/Lorenz96/bocquet2010_m40.py
@@ -5,13 +5,13 @@ import dapper.mods as modelling
 from dapper.mods.Lorenz96.bocquet2010 import Dyn, tseq
 
 Nx = 40
-Dyn['M'] = Nx
+Dyn = modelling.Operator(M=Nx)
 
 X0 = modelling.GaussRV(M=Nx, C=0.001)
 
 jj = np.arange(0, Nx, 2)
 Obs = modelling.partial_Id_Obs(Nx, jj)
-Obs['noise'] = 1.5
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=1.5)
 
 HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0)
 

--- a/dapper/mods/Lorenz96/frei2013bridging.py
+++ b/dapper/mods/Lorenz96/frei2013bridging.py
@@ -14,19 +14,13 @@ from dapper.tools.localization import nd_Id_localization
 t = modelling.Chronology(0.05, dto=0.4, T=4**5, BurnIn=20)
 
 Nx = 40
-Dyn = {
-    'M': Nx,
-    'model': step,
-    'linear': dstep_dx,
-    'noise': 0,
-}
+Dyn = modelling.Operator(M=Nx, model=step, linear=dstep_dx, noise=0)
 
 X0 = modelling.GaussRV(M=Nx, C=0.001)
 
 jj = 1 + np.arange(0, Nx, 2)
 Obs = modelling.partial_Id_Obs(Nx, jj)
-Obs['noise'] = 0.5
-Obs['localizer'] = nd_Id_localization((Nx,), (2,), jj)
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=0.5, localizer=nd_Id_localization((Nx,), (2,), jj))
 
 HMM = modelling.HiddenMarkovModel(Dyn, Obs, t, X0)
 

--- a/dapper/mods/Lorenz96/miyoshi2011.py
+++ b/dapper/mods/Lorenz96/miyoshi2011.py
@@ -20,12 +20,12 @@ ocean_sites = np.arange(Nx//2, Nx)
 
 jj = land_sites
 Obs = modelling.partial_Id_Obs(Nx, jj)
-Obs['noise'] = 1
-Obs['localizer'] = nd_Id_localization((Nx,), (1,), jj)
+
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=1, localizer=nd_Id_localization((Nx,), (1,), jj))
 
 HMM = modelling.HiddenMarkovModel(
     Dyn, Obs, t, X0,
-    LP=LPs(jj),
+    liveplotters=LPs(jj),
     sectors={'land': land_sites,
              'ocean': ocean_sites},
 )

--- a/dapper/mods/Lorenz96/pinheiro2019.py
+++ b/dapper/mods/Lorenz96/pinheiro2019.py
@@ -10,21 +10,15 @@ tseq = modelling.Chronology(0.01, dko=10, K=4000, Tplot=10, BurnIn=10)
 
 Nx = 1000
 
-Dyn = {
-    'M': Nx,
-    'model': step,
-    # It's not clear from the paper whether Q=0.5 or 0.25.
-    # But I'm pretty sure it's applied each dto (not dt).
-    'noise': 0.25 / tseq.dto,
-    # 'noise': 0.5 / t.dto,
-}
+# It's not clear from the paper whether Q=0.5 or 0.25.
+# But I'm pretty sure it's applied each dto (not dt).
+Dyn = modelling.Operator(M=Nx, model=step, noise=0.25 / tseq.dto)
 
 X0 = modelling.GaussRV(mu=x0(Nx), C=0.001)
 
 jj = linspace_int(Nx, Nx//4, periodic=True)
 Obs = modelling.partial_Id_Obs(Nx, jj)
-Obs['noise'] = 0.1**2
-Obs['localizer'] = nd_Id_localization((Nx,), (1,), jj, periodic=True)
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=0.1**2, localizer=nd_Id_localization((Nx,), (1,), jj, periodic=True))
 
 HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0)
 

--- a/dapper/mods/Lorenz96/sakov2008.py
+++ b/dapper/mods/Lorenz96/sakov2008.py
@@ -18,19 +18,14 @@ tseq = modelling.Chronology(0.05, dko=1, Ko=1000, Tplot=Tplot, BurnIn=2*Tplot)
 Nx = 40
 x0 = x0(Nx)
 
-Dyn = {
-    'M': Nx,
-    'model': step,
-    'linear': dstep_dx,
-    'noise': 0,
-}
+Dyn = modelling.Operator(M=Nx, model=step, linear=dstep_dx, noise=0)
 
 X0 = modelling.GaussRV(mu=x0, C=0.001)
 
 jj = np.arange(Nx)  # obs_inds
 Obs = modelling.partial_Id_Obs(Nx, jj)
-Obs['noise'] = 1
-Obs['localizer'] = nd_Id_localization((Nx,), (2,))
+
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=1, localizer=nd_Id_localization((Nx,), (2,)))
 
 HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0)
 

--- a/dapper/mods/Lorenz96/spectral_obs.py
+++ b/dapper/mods/Lorenz96/spectral_obs.py
@@ -97,11 +97,7 @@ H = make_H(Ny, Nx)
 # plt.figure(1).gca().matshow(H)
 # plt.figure(2).gca().matshow(H @ H.T)
 
-Obs = {
-    'M': Ny,
-    'model': lambda x, t: x @ H.T,
-    'noise': modelling.GaussRV(C=0.01*np.eye(Ny)),
-}
+Obs = modelling.Operator(M=Ny, model=lambda x, t: x @ H.T, noise=modelling.GaussRV(C=0.01*np.eye(Ny)))
 
 HMM = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0)
 

--- a/dapper/mods/Lorenz96/todter2015.py
+++ b/dapper/mods/Lorenz96/todter2015.py
@@ -10,19 +10,15 @@ from dapper.tools.localization import nd_Id_localization
 t = modelling.Chronology(0.05, dko=2, T=4**5, BurnIn=20)
 
 Nx = 80
-Dyn = {
-    'M': Nx,
-    'model': step,
-    'noise': 0,
-}
+
+Dyn = modelling.Operator(M=Nx, model=step, noise=0)
 
 X0 = modelling.GaussRV(M=Nx, C=0.001)
 
 jj = np.arange(0, Nx, 2)
 Obs = modelling.partial_Id_Obs(Nx, jj)
-Obs['localizer'] = nd_Id_localization((Nx,), (1,), jj)
-# Obs['noise'] = RVs.LaplaceRV(C=1,M=len(jj))
-Obs['noise'] = RVs.LaplaceParallelRV(C=1, M=len(jj))
+
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=RVs.LaplaceParallelRV(C=1, M=len(jj)), localizer=nd_Id_localization((Nx,), (1,), jj))
 
 HMM = modelling.HiddenMarkovModel(Dyn, Obs, t, X0)
 

--- a/dapper/mods/LorenzUV/lorenz96.py
+++ b/dapper/mods/LorenzUV/lorenz96.py
@@ -18,19 +18,14 @@ nU = LUV.nU
 tseq = modelling.Chronology(dt=0.005, dto=0.05, T=4**3, BurnIn=6)
 
 
-Dyn = {
-    'M': LUV.M,
-    'model': modelling.with_rk4(LUV.dxdt, autonom=True),
-    'noise': 0,
-    'linear': LUV.dstep_dx,
-}
+Dyn = modelling.Operator(M=LUV.M, model=modelling.with_rk4(LUV.dxdt, autonom=True), linear=LUV.dstep_dx, noise=0)
 
 X0 = modelling.GaussRV(mu=LUV.x0, C=0.01)
 
 R = 1.0
 jj = np.arange(nU)
 Obs = modelling.partial_Id_Obs(LUV.M, jj)
-Obs['noise'] = R
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=R)
 
 other = {'name': rel2mods(__file__)+'_full'}
 HMM_full = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0, **other)
@@ -43,17 +38,13 @@ HMM_full = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0, **other)
 # Just change dt from 005 to 05
 tseq = modelling.Chronology(dt=0.05, dto=0.05, T=4**3, BurnIn=6)
 
-Dyn = {
-    'M': nU,
-    'model': modelling.with_rk4(LUV.dxdt_parameterized),
-    'noise': 0,
-}
+Dyn = modelling.Operator(M=LUV.M, model=modelling.with_rk4(LUV.dxdt_parameterized), noise=0)
 
 X0 = modelling.GaussRV(mu=LUV.x0[:nU], C=0.01)
 
 jj = np.arange(nU)
 Obs = modelling.partial_Id_Obs(nU, jj)
-Obs['noise'] = R
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=R)
 
 other = {'name': rel2mods(__file__)+'_trunc'}
 HMM_trunc = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0, **other)

--- a/dapper/mods/LorenzUV/wilks05.py
+++ b/dapper/mods/LorenzUV/wilks05.py
@@ -26,22 +26,16 @@ nU = LUV.nU
 tseq = modelling.Chronology(dt=0.005, dto=0.05, T=4**3, BurnIn=6)  # requires rk4
 
 
-Dyn = {
-    'M': LUV.M,
-    'model': modelling.with_rk4(LUV.dxdt, autonom=True),
-    'noise': 0,
-    'linear': LUV.dstep_dx,
-}
+Dyn = modelling.Operator(M=LUV.M, model=modelling.with_rk4(LUV.dxdt, autonom=True), linear=LUV.dstep_dx, noise=0)
 
 X0 = modelling.GaussRV(mu=LUV.x0, C=0.01)
 
 R = 0.1
 jj = np.arange(nU)
 Obs = modelling.partial_Id_Obs(LUV.M, jj)
-Obs['noise'] = R
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=R)
 
-other = {'name': rel2mods(__file__)+'_full'}
-HMM_full = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0, LP=LUV.LPs(jj), **other)
+HMM_full = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0, liveplotters=LUV.LPs(jj), name=rel2mods(__file__)+'_full')
 
 
 ################
@@ -51,20 +45,15 @@ HMM_full = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0, LP=LUV.LPs(jj), **oth
 # Just change dt from 005 to 05
 tseq = modelling.Chronology(dt=0.05, dto=0.05, T=4**3, BurnIn=6)
 
-Dyn = {
-    'M': nU,
-    'model': modelling.with_rk4(LUV.dxdt_parameterized),
-    'noise': 0,
-}
+Dyn = modelling.Operator(M=nU, model=modelling.with_rk4(LUV.dxdt_parameterized), noise=0)
 
 X0 = modelling.GaussRV(mu=LUV.x0[:nU], C=0.01)
 
 jj = np.arange(nU)
 Obs = modelling.partial_Id_Obs(nU, jj)
-Obs['noise'] = R
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=R)
 
-other = {'name': rel2mods(__file__)+'_trunc'}
-HMM_trunc = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0, LP=LUV.LPs(jj), **other)
+HMM_trunc = modelling.HiddenMarkovModel(Dyn, Obs, tseq, X0, liveplotters=LUV.LPs(jj), name=rel2mods(__file__)+'_trunc')
 
 LUV.prmzt = lambda x, t: polynom_prmzt(x, t, 1)
 

--- a/dapper/mods/LotkaVolterra/settings101.py
+++ b/dapper/mods/LotkaVolterra/settings101.py
@@ -13,20 +13,15 @@ t = modelling.Chronology(0.5, dto=10, T=1000, BurnIn=Tplot, Tplot=Tplot)
 
 Nx = len(x0)
 
-Dyn = {
-    'M': Nx,
-    'model': step,
-    'linear': dstep_dx,
-    'noise': 0,
-    }
+Dyn = modelling.Operator(M=Nx, model=step, linear=dstep_dx, noise=0)
 
 X0 = modelling.GaussRV(mu=x0, C=0.01**2)
 
 jj = [1, 3]
 Obs = modelling.partial_Id_Obs(Nx, jj)
-Obs['noise'] = 0.04**2
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=0.04**2)
 
-HMM = modelling.HiddenMarkovModel(Dyn, Obs, t, X0, LP=LP_setup(jj))
+HMM = modelling.HiddenMarkovModel(Dyn, Obs, t, X0, liveplotters=LP_setup(jj))
 
 ####################
 # Suggested tuning

--- a/dapper/mods/__init__.py
+++ b/dapper/mods/__init__.py
@@ -3,12 +3,20 @@
 .. include:: ./README.md
 """
 
+from __future__ import annotations
+
 import copy as cp
 import inspect
+from optparse import Option
 from pathlib import Path
+from typing import Optional, List, Dict, TYPE_CHECKING, Callable, Union, Any
+from webbrowser import Opera
 
 import numpy as np
 import struct_tools
+
+if TYPE_CHECKING:  # Only imports the below statements during type checking
+    from dapper.mods import Operator
 
 # Imports used to set up HMMs
 import dapper.tools.progressbar as pb
@@ -23,6 +31,13 @@ from dapper.tools.seeding import set_seed
 from .integration import with_recursion, with_rk4
 from .utils import Id_Obs, ens_compatible, linspace_int, partial_Id_Obs
 
+def _default_name() -> str:
+    name = inspect.getfile(inspect.stack()[2][0])
+    try:
+        name = str(Path(name).relative_to(rc.dirs.dapper/'mods'))
+    except ValueError:
+        name = str(Path(name))
+    return name
 
 class HiddenMarkovModel(struct_tools.NicePrint):
     """Container for a Hidden Markov Model (HMM).
@@ -60,56 +75,22 @@ class HiddenMarkovModel(struct_tools.NicePrint):
         Label for the `HMM`.
     """
 
-    def __init__(self, *args, **kwargs):
-        # Valid args/kwargs, along with type and default.
-        # Note: it's still ok to write attributes to the HMM following the init.
-        attrs = dict(Dyn=(Operator, None),
-                     Obs=(Operator, None),
-                     tseq=(Chronology, None),
-                     X0=(RV, None),
-                     liveplotters=(list, []),
-                     sectors=(dict, {}),
-                     name=(str, HiddenMarkovModel._default_name))
+    def __init__(self, 
+        Dyn: Optional[Operator] = None, 
+        Obs: Optional[Operator] = None,
+        tseq: Optional[Chronology] = None,
+        X0: Optional[RV] = None,
+        liveplotters: Optional[List[Callable]] = None,
+        sectors: Optional[Dict[str, np.array]] = None,
+        name: Optional[str] = _default_name()):
 
-        # Transfer args to kwargs
-        for arg, kw in zip(args, attrs):
-            assert (kw not in kwargs), "Could not sort out arguments."
-            kwargs[kw] = arg
-
-        # Un-abbreviate
-        abbrevs = {"LP": "liveplotters", "loc": "localizer"}
-        for k in list(kwargs):
-            try:
-                full = abbrevs[k]
-            except KeyError:
-                pass
-            else:
-                assert (full not in kwargs), "Could not sort out arguments."
-                kwargs[full] = kwargs.pop(k)
-
-        # Transfer kwargs to self
-        for k, (type_, default) in attrs.items():
-            # Get kwargs[k] or default
-            if k in kwargs:
-                v = kwargs.pop(k)
-            elif callable(default):
-                v = default()
-            else:
-                v = default
-            # Convert dict to type
-            if not isinstance(v, (type_, type(None))):
-                v = type_(**v)
-            # Write
-            setattr(self, k, v)
-        assert kwargs == {}, f"Arguments {list(kwargs)} is/are invalid."
-
-        # Further defaults
-        if not hasattr(self.Obs, "localizer"):
-            self.Obs.localizer = no_localization(self.Nx, self.Ny)
-
-        # Validation
-        if self.Obs.noise.C == 0 or self.Obs.noise.C.rk != self.Obs.noise.C.M:
-            raise ValueError("Rank-deficient R not supported.")
+        self.Dyn = Dyn
+        self.Obs = Obs
+        self.tseq = tseq
+        self.X0 = X0
+        self.liveplotters = [] if liveplotters is None else liveplotters
+        self.sectors = {} if sectors is None else sectors
+        self.name = name
 
     # ndim shortcuts
     @property
@@ -143,16 +124,6 @@ class HiddenMarkovModel(struct_tools.NicePrint):
     def copy(self):
         return cp.deepcopy(self)
 
-    @staticmethod
-    def _default_name():
-        name = inspect.getfile(inspect.stack()[2][0])
-        try:
-            name = str(Path(name).relative_to(rc.dirs.dapper/'mods'))
-        except ValueError:
-            name = str(Path(name))
-        return name
-
-
 class Operator(struct_tools.NicePrint):
     """Container for the dynamical and the observational maps.
 
@@ -162,22 +133,39 @@ class Operator(struct_tools.NicePrint):
         Length of output vectors.
     model: function
         The actual operator.
+    linear: 
     noise: RV, optional
         The associated additive noise. The noise can also be a scalar or an
         array, producing `GaussRV(C=noise)`.
+    localizer: TODO: Describe
+    object : TODO: Describe
+    loc_shift : TODO: Describe
 
     Any remaining keyword arguments are written to the object as attributes.
     """
 
-    def __init__(self, M, model=None, noise=None, **kwargs):
+    def __init__(self, M: int, model: Optional[Callable] = None, 
+        linear: Optional[Callable] = None, 
+        noise: Optional[Union[RV, float]] = None, 
+        localizer: Any = None, # TODO: Add proper type hints
+        object: Any = None, # TODO: Add proper type hints
+        loc_shift: Any = None # TODO: Add proper type hints
+        ):
+        
         self.M = M
-
+        self.model = model
+        self.linear = linear
+        self.noise = noise
+        self.localizer = localizer
+        self.object = object
+        self.loc_shift = loc_shift
+        
         # Default to the Identity operator
         if model is None:
-            model = Id_op()
-            kwargs['linear'] = lambda *args: np.eye(M)
-        # Assign
-        self.model = model
+            self.model = Id_op()
+
+        if linear is None:
+            self.linear = lambda *args: np.eye(M)
 
         # None/0 => No noise
         if isinstance(noise, RV):
@@ -190,10 +178,7 @@ class Operator(struct_tools.NicePrint):
             else:
                 self.noise = GaussRV(C=noise)
 
-        # Write attributes
-        for key, value in kwargs.items():
-            setattr(self, key, value)
-
+    # TODO: Probably good to remove this and force users to call Dyn.model(...) - explicit is better
     def __call__(self, *args, **kwargs):
         return self.model(*args, **kwargs)
 

--- a/dapper/mods/explore_props.py
+++ b/dapper/mods/explore_props.py
@@ -93,18 +93,6 @@ if __name__ == "__main__":
         eps   = 0.001
         N     = 66  # Don't need all Nx for a good approximation of upper spectrum.
 
-    # Lyapunov exponents: [8.36, 7.58, 7.20, 6.91, ..., -4.18, -4.22, -4.19] => n0≈164
-    if mod == "L05":
-        from dapper.mods.LorenzIII import Model
-        model = Model()
-        step  = model.step
-        x0    = model.x0
-        dt    = 0.05/12
-        Nx    = len(x0)
-        N     = 400
-        T     = 1e2
-        eps   = 0.0002
-
     # Lyapunov exponents: [  0.08   0.07   0.06 ... -37.9  -39.09 -41.55]
     if mod == "KS":
         from dapper.mods.KS import Model

--- a/examples/evensen_advection.py
+++ b/examples/evensen_advection.py
@@ -1,0 +1,13 @@
+import dapper.da_methods as da
+
+from dapper.mods.LA.evensen2009 import HMM
+
+xx, yy = HMM.simulate()
+
+xp = da.EnKF("PertObs", N=2)
+
+# Feda: based on the docstring of `liveplotters` of HiddenMarkovModel,
+#       xp.assimilate(...) should plot stuff if HMM has LivePlotters attached to it.
+#       this seems not to happen.
+# xp.assimilate(HMM, xx, yy,   liveplots=["spatial1d"])
+xp.assimilate(HMM, xx, yy)

--- a/examples/param_estim.py
+++ b/examples/param_estim.py
@@ -80,17 +80,15 @@ tseq = modelling.Chronology(
     Tplot=7)     # Default plot length
 
 # Define dynamical model
-Dyn = {
-    'M': Nx+Np,     # Length of (total/augmented) state vector
-    'model': step,  # Actual model
-    'noise': 0,     # Additive noise (variance)
-    # 'noise': GaussRV(C=.1*np.eye(Nx+Np)),
-}
+Dyn = modelling.Operator(M=Nx+Np, # Length of (total/augmented) state vector
+    model=step, # Actual model
+    noise=0 # Additive noise (variance)
+)
 
 # Define observation model using convenience function partial_Id_Obs
 jj = np.arange(Nx)  # obs indices (y = x[jj])
 Obs = modelling.partial_Id_Obs(Nx+Np, jj)
-Obs['noise'] = 1
+Obs = modelling.Operator(M=Obs.get("M"), model=Obs.get("model"), linear=Obs.get("linear"), noise=1)
 
 # Specify liveplotting (and replay) functionality.
 LP = [

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ DOCLINES = __doc__.split('\n')
 
 # Dependencies
 INSTALL_REQUIRES = [
-    'scipy>=1.1',
+    'scipy',
+    "numpy >= 1.20.0"
     'ipython>=5.1',
     'jedi<0.18',  # ipython/issues/12740
     'jupyter',

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -8,7 +8,7 @@ from dapper.mods.LA import Fmat
 
 def test_operator_defaults():
     M = 3
-    op = modelling.Operator(**{"M": M})
+    op = modelling.Operator(M=3)
     assert (op.linear() == np.identity(M)).all()
     assert op.model(3) == 3
     assert op.model(3, 2, 1) == 3

--- a/types-requirements.txt
+++ b/types-requirements.txt
@@ -1,0 +1,3 @@
+types-tabulate
+types-PyYAML
+types-python-dateutil


### PR DESCRIPTION
- Explicit constructor with type hints for `HiddenMarkovModel` and `Operator`.
- `Dyn` and `Obs` can only be of type `Operator` and not `Operator` and `dict`.
- Shorthand `LP` for `liveplotters` no longer allowed.